### PR TITLE
Fix typo 'username' variable throwing error on open from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then cool UI will appear.
 ```python
 >>> from spotify_dlx import SpotifyDLXClient
 >>> client = SpotifyDLXClient()
->>> client.login(usename="USERNAME", password="PASSWORD")
+>>> client.login(username="USERNAME", password="PASSWORD")
 >>> client.search("Billie Eilish")
 ```
 

--- a/spotify_dlx/__main__.py
+++ b/spotify_dlx/__main__.py
@@ -32,7 +32,7 @@ def _login(client: SpotifyDLXClient) -> None:
         print("Credentials are loaded from env vars:sparkles:")
         username = os.getenv("SPOTIFY_USERNAME")
         password = os.getenv("SPOTIFY_PASSWORD")
-        client.login(usename=username, password=password)
+        client.login(username=username, password=password)
 
     # Ask user to type username and password.
     else:


### PR DESCRIPTION
When opening with `python -m SpotifyDLX` in a shell, it throws this error: 

```
Credentials are loaded from env vars✨
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "path/spotify_dlx/spotify_dlx/__main__.py", line 100, in <module>
    _main()
  File "path/spotify_dlx/spotify_dlx/__main__.py", line 77, in _main
    _login(client)
  File "path/spotify_dlx/spotify_dlx/__main__.py", line 35, in _login
    client.login(usename=username, password=password)
TypeError: SpotifyDLXClient.login() got an unexpected keyword argument 'usename'
```

This seems fairly clearly to be a typo where `__main__.py` is passing `usename`, but the login method in `spotify_dlx.py` is expecting `username`. I've simply fixed the typo. Thereafter `python -m SpotifyDLX` behaves as predicted in the README.